### PR TITLE
96-90-download_box_private.md

### DIFF
--- a/96-90-download_box_private.md
+++ b/96-90-download_box_private.md
@@ -9,18 +9,56 @@ This script downloads files from a private Box folder using JWT authentication. 
 ## Usage
 
 ```bash
-download_box_private.py SUBFOLDER [options]
+python download_box_private.py SUBFOLDER [options]
 ```
 
-## Arguments
+### Arguments
 
-- **SUBFOLDER** (Required) - Subfolder identifier (downloads from 'aearep-SUBFOLDER')
+- **SUBFOLDER** (Required) - Subfolder identifier (downloads from 'aearep-SUBFOLDER'). This will be the tag of the main Jira ticket, such as aearep-1234.
 
-## Example
+### Example
 
 ```bash
-download_box_private.py 1234  # Download from subfolder 'aearep-1234'
+python tools/download_box_private.py 1234  # Download from subfolder 'aearep-1234'
 ```
+
+## Requirements
+
+- Python 3.x
+- boxsdk: Box Python SDK
+- Valid Box JWT application credentials
+
+### Installing Box SDK
+
+- The above dependencies can be installed in a virtual environment or on your system. Installing the Box Python SDK requires two packages:
+
+```shell
+conda install box-sdk-gen
+conda install box-sdk-gen[jwt]
+```
+
+- This can be done through conda, or in pip, or pipx. 
+
+## Using AEA Credentials
+
+To permantently set the proper credentials on BioHPC, you can modify your `~/.bashrc` profile. This will contain the environmental variables required for logging in. Your `~/.bashrc` will look something like
+
+```shell
+MLM_LICENSE_FILE=00000@licenseserver.cornell.edu
+SDRIVE = "Path/On/SDRIVE"
+BOX_FOLDER_ID = 123456789012
+BOX_PRIVATE_KEY_ID = abcd123
+BOX_ENTERPRISE_ID = 12345
+BOX_FOLDER_PRIVATE = 123456789012
+BOX_PRIVATE_JSON = "
+
+
+"
+
+
+```
+
+- These values can be obtained from a supervisor.
 
 ## Environment Variables
 
@@ -78,12 +116,6 @@ restricted/                 # Default output directory (configurable)
     ├── file2.pdf
     └── ...
 ```
-
-## Requirements
-
-- Python 3.x
-- boxsdk: Box Python SDK
-- Valid Box JWT application credentials
 
 ## Box Application Setup
 

--- a/96-90-download_box_private.md
+++ b/96-90-download_box_private.md
@@ -9,7 +9,7 @@ This script downloads files from a private Box folder using JWT authentication. 
 ## Usage
 
 ```bash
-python download_box_private.py SUBFOLDER [options]
+python tools/download_box_private.py SUBFOLDER [options]
 ```
 
 ### Arguments

--- a/96-90-download_box_private.md
+++ b/96-90-download_box_private.md
@@ -41,24 +41,7 @@ conda install box-sdk-gen[jwt]
 
 ## Using AEA Credentials
 
-To permantently set the proper credentials on BioHPC, you can modify your `~/.bashrc` profile. This will contain the environmental variables required for logging in. Your `~/.bashrc` will look something like
-
-```shell
-MLM_LICENSE_FILE=00000@licenseserver.cornell.edu
-SDRIVE = "Path/On/SDRIVE"
-BOX_FOLDER_ID = 123456789012
-BOX_PRIVATE_KEY_ID = abcd123
-BOX_ENTERPRISE_ID = 12345
-BOX_FOLDER_PRIVATE = 123456789012
-BOX_PRIVATE_JSON = "
-
-
-"
-
-
-```
-
-- These values can be obtained from a supervisor.
+To permantently set the proper credentials on BioHPC, you can modify your `~/.bashrc` profile, to include the box environmental variables. These values can be obtained from a supervisor.
 
 ## Environment Variables
 

--- a/96-90-download_box_private.md
+++ b/96-90-download_box_private.md
@@ -33,9 +33,10 @@ python tools/download_box_private.py 1234  # Download from subfolder 'aearep-123
 - The above dependencies can be installed in a virtual environment or on your system. Installing the Box Python SDK requires two packages:
 
 ```shell
-conda install box-sdk-gen
-conda install box-sdk-gen[jwt]
+conda install boxsdk
+conda install boxsdk[jwt]
 ```
+- Currently, box is updating the box-python-sdk. This script will work only with `boxsdk`, not the newer `box-sdk-gen`. 
 
 - This can be done through conda, or in pip, or pipx. 
 

--- a/96-90-download_box_private.md
+++ b/96-90-download_box_private.md
@@ -36,7 +36,7 @@ python tools/download_box_private.py 1234  # Download from subfolder 'aearep-123
 conda install boxsdk
 conda install boxsdk[jwt]
 ```
-- Currently, box is updating the box-python-sdk. This script will work only with `boxsdk`, not the newer `box-sdk-gen`. 
+- Currently, box is updating boxsdk to box-sdk-gen. This script will work only with `boxsdk`, not the newer `box-sdk-gen`. 
 
 - This can be done through conda, or in pip, or pipx. 
 


### PR DESCRIPTION
Clarifying 96-90-download_box_private.md, and adding AEA specific details. 
- Modified commands to use `python`, as well as point to `tools/download_box_private.py`. 
- Added boxsdk[jwt] to the requirements. This was required for me to download.
- Added conda install directions. Not sure if this is really required?
- Added details about the jwt authentication, added in .bashrc. 

These changes are based on BioHPC experience. Not sure if they generalize to ccss cloud, though they should. 