### PR TITLE
Clarify Windows network drive mapping instructions

### DIFF
--- a/95-10-windows-remote.md
+++ b/95-10-windows-remote.md
@@ -67,10 +67,10 @@ use the [https://client.wvd.microsoft.com/arm/webclient/](https://client.wvd.mic
 
 **Mapping Network Drives**
 
-- You should map the following network drive, following the **instructions** linked above (see the document "**3. Cloud Storage**")
+- You should map the following network drive, following the CCSS storage/network-drive instructions linked above. Note that `L:` is the LDI-specific drive letter for this setup.
   - `\\ccssilr.file.core.windows.net\lv39` to drive letter `L:` (you can call it "LDILab Drive")
-  - We will be using that drive letter often (including to replace the `S:` drive from the CCSS classic nodes).
-
+  - We will be using that drive letter often. On Cloud CCSS, `L:` replaces the `S:` drive from the CCSS classic nodes.
+    
 - When instructed, you may also need to map the old S-drive:
   - `\\rschfs2x.ciserrsch.cornell.edu\share\LDIlab`
   - Select “Connect using different credentials”


### PR DESCRIPTION
Clarifies the Windows setup page by removing the outdated “3. Cloud Storage” reference and distinguishing the LDI-specific L: drive mapping from the old CCSS-RS/CISER S: drive mapping.