### PR TITLE
Update 95-15-linux-remote.md

### DIFF
--- a/95-15-linux-remote.md
+++ b/95-15-linux-remote.md
@@ -14,7 +14,7 @@ We have access to various Linux clusters:
 Run this ONCE the first time you ever access any Linux servers:
 
 ```
-echo "umask 007" >> $HOME/.bash_profile
+echo "umask 007" >> $HOME/.bashrc
 ```
 
 Then do the usual [Bash setup](setup-bash). That should work on nearly any Linux server.


### PR DESCRIPTION
Adding "umask 007" to .bash_profile won't apply the setting automatically when logging in through VS Code instead of PuTTY. Placing it in .bashrc ensures it is loaded in VS Code, and since .bash_profile sources .bashrc, it will still apply in PuTTY login sessions.