### PR TITLE
Document the new Software used checkbox + other-text fields

### DIFF
--- a/11-01-workflow-assigned.md
+++ b/11-01-workflow-assigned.md
@@ -30,7 +30,7 @@ Is the current Jira issue an **original report** (first time we see the manuscri
     - Once you have entered the previous repository "stub" into the `Bitbucket short name` field, you can proceed to [`In Progress`](in-progress).
 
 ```{warning}
-If a field on Jira is already filled out, **do not edit it**. The only exception is if software is missing from the `Software used` field.
+If a field on Jira is already filled out, **do not edit it**. The only exception is the `Software used` checkbox field and the `Software used (other)` text field: the pipeline automatically checks/fills these in as it scans the deposit's code, so treat them as review-only, but add anything missing that the pipeline can't detect from code alone (e.g. Excel, ArcGIS, QGIS, Dynare, or any other GUI-only or non-code-file software).
 ```
 
 ## If this is not a revision

--- a/11-05-preparing-to-run-code.md
+++ b/11-05-preparing-to-run-code.md
@@ -158,12 +158,16 @@ Now is a good time to understand the code in a bit more detail:
   - Use this to create a list of all Tables and Figures in the paper
   - You will use this to guide later to tabulate your findings!
 - [ ] Fill out the "**Code Description**" section of the `REPLICATION-PartB.md`
-  - Provide some information about the program files (are there 3 Stata files? Are there 5 Matlab programs?). You will use this information to fill out the `Software Used` (in the main task) later as well, but provide details here.
+  - Provide some information about the program files (are there 3 Stata files? Are there 5 Matlab programs?). Provide details here.
     - You can use the file "`generated/programs-list.txt` to help you here.
   - Did you have difficulty aligning the README with the files? Does the sequence suggested by the programs differ from what's written in the README? 
   - Are there files in the archive not explained in the README?
   - Copy-and-paste the *code-check.xlsx* into the code description part, listing the programs. Omit the "Reproduced?" Column in doing so. Use the [Excel-to-Markdown plugin](https://marketplace.visualstudio.com/items?itemName=csholmq.excel-to-markdown-table) for VSCode. 
     - This table will be pasted in under "Findings" again, with "Reproduced?" column, once code has been run.
+
+```{note} Software used field
+By this point, the `Software used` checkbox field on the main task should already be checked automatically from the program files the pipeline scanned. **Review it rather than filling it in from scratch** — correct anything wrong, and add anything the pipeline can't detect from code alone (GUI-only or data-analysis tools like Excel, ArcGIS, QGIS; or command languages without a distinct file extension, like Dynare) to the `Software used (other)` text field. See the Excel-handling note in [Checking Unassigned Tickets](checking-unassigned-tickets) — only check Excel if it actively computes values or produces a figure, not if it's just used to store data.
+```
 
 ## Verify that you can actually run the code
 

--- a/20-checking-unassigned-tickets.md
+++ b/20-checking-unassigned-tickets.md
@@ -1,3 +1,4 @@
+(checking-unassigned-tickets)=
 # Checking Unassigned Jira Tickets
 
 ## Setup
@@ -78,7 +79,16 @@ Now you need to open the draft replication deposit (typically, but not always on
 - Click on the `Replication Package URL`, which will open up a separate tab. 
 - Find the README in the deposit.
 - Click on the README (you can preview, probably do not need to download) and scan through to identify the software used
-- Go to the tab `Repl info` and add the software identified to the  `Software Used` field.
+- Go to the tab `Repl info` and check the software identified in the `Software used` field (Stata, MATLAB, R, Python, SAS, Julia, Excel, Fortran, Mathematica, Dynare, QGIS, ArcGIS). If software is used that isn't one of these checkboxes, type it into the `Software used (other)` text field instead.
+
+```{note}
+Once the deposit's code is pulled and scanned (during [Preparing to run code](prepare-to-run-code)), the pipeline automatically checks the boxes for anything it recognizes from the program files. This early pass from the README is just a first guess and will be refined automatically later — don't worry about being exhaustive here.
+```
+
+```{admonition} How to handle Excel
+:class: tip
+Only check `Excel` if it was used to **actively compute values or produce a chart/figure** as part of the analysis. If Excel is only used to store or view data (a `.xlsx`/`.xls` file with no formulas or macros driving the analysis), do not check it — that's a data format, not software used for the analysis.
+```
 
 ```{admonition} If there is no README...
 :class: dropdown


### PR DESCRIPTION
## Summary
- Jira's "Software used" field is now a checkbox field (Stata, MATLAB, R, Python, SAS, Julia, Excel, Fortran, Mathematica, Dynare, QGIS, ArcGIS) auto-populated by the pipeline as it scans code, plus a free-text "Software used (other)" field for anything else. The old free-text field is retained as "Software used (v1)" for history but is no longer editable on screens.
- Updates `11-01-workflow-assigned.md`, `20-checking-unassigned-tickets.md`, and `11-05-preparing-to-run-code.md` to describe these fields as review-only once the pipeline has run, since it now auto-detects software from code files.
- Adds guidance on when Excel counts as "software used": only if it actively computes values or produces a chart/figure, not if it's just used to store/view data.

## Test plan
- [x] Verified MyST cross-reference anchors (`checking-unassigned-tickets`, `prepare-to-run-code`) resolve to existing/added labels
- [ ] Manual maintainer to confirm rendered docs build correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)