### PR TITLE
Add Cloudflare Pages PR previews

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,3 +101,44 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/html
+
+  # Deploy a live per-PR preview to Cloudflare Pages, for pull requests
+  # opened from a branch of this repository (not a fork -- forks can't
+  # read deploy secrets). Posts (or updates) the preview link as a PR
+  # comment. See README-DEPLOYMENT.md for the one-time Cloudflare setup.
+  preview:
+    needs: build
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write     # only for the PR comment
+    steps:
+    - name: Download built HTML
+      uses: actions/download-artifact@v5
+      with:
+        name: book-html
+        path: ./_build/html
+
+    - name: Deploy PR preview
+      id: preview
+      uses: cloudflare/wrangler-action@v4
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: >-
+          pages deploy ./_build/html
+          --project-name=${{ github.event.repository.name }}
+          --branch=pr-${{ github.event.pull_request.number }}
+
+    - name: Publish preview link
+      if: steps.preview.outcome == 'success'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        PR: ${{ github.event.pull_request.number }}
+        URL: ${{ steps.preview.outputs.pages-deployment-alias-url }}
+      run: |
+        echo "📖 Preview: $URL" >> "$GITHUB_STEP_SUMMARY"
+        gh pr comment "$PR" --repo "$REPO" --edit-last --create-if-none \
+          --body "📖 **Preview:** $URL — commit \`${GITHUB_SHA:0:7}\`"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _book
 _bookdown_files
 rsconnect
 .myenv
+.wrangler

--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -1,0 +1,109 @@
+# Deployment & PR previews
+
+This repo's manual is built with Jupyter Book and published to `gh-pages`
+via [.github/workflows/main.yml](.github/workflows/main.yml). That workflow
+has four jobs:
+
+- **build** — always runs (push to `main`, pull requests). Builds the
+  Jupyter Book HTML and uploads it as a workflow artifact named
+  `book-html`.
+- **build-pdf** — always runs alongside `build`. Builds the printable PDF
+  and uploads it as a workflow artifact named `book-pdf`.
+- **deploy** — runs only on pushes to `main`. Downloads `book-html` (and
+  `book-pdf`, if it built successfully) and pushes them to the `gh-pages`
+  branch, which serves the live site.
+- **preview** — runs on pull requests opened from a branch of this
+  repository (not a fork). Downloads the `book-html` artifact and deploys
+  it to [Cloudflare Pages](https://pages.cloudflare.com/) as a per-PR
+  preview, then posts (or updates) a comment on the PR with the preview
+  link.
+
+Forked PRs never run the `preview` job's deploy step, since forks don't have
+access to repository secrets — that's a GitHub Actions security boundary,
+not a bug.
+
+The Cloudflare Pages **project name is derived automatically** from the
+GitHub repository name (`${{ github.event.repository.name }}` in the
+workflow) — currently `ldilab-manual`. Nothing in the workflow needs
+editing if the repo is ever renamed; only the one-time Cloudflare project
+creation below needs to match.
+
+## One-time Cloudflare Pages setup
+
+You need a Cloudflare account and an API token before the `preview` job can
+deploy anything.
+
+1. **Create the Cloudflare API token.**
+   In the Cloudflare dashboard: **My Profile → API Tokens → Create Token**,
+   using a custom token with `Account.Cloudflare Pages: Edit` permission.
+   Copy the token value — it's only shown once.
+
+2. **Find your Cloudflare Account ID.**
+   It's shown on the right-hand sidebar of any zone/domain overview page in
+   the Cloudflare dashboard, or via `wrangler whoami` if you have Wrangler
+   installed locally.
+
+3. **Set both as GitHub Actions secrets on this repo**, using the `gh` CLI
+   (run from the repo root, or add `--repo labordynamicsinstitute/ldilab-manual`
+   from elsewhere):
+
+   ```bash
+   gh secret set CLOUDFLARE_API_TOKEN --body "<paste the API token>"
+   gh secret set CLOUDFLARE_ACCOUNT_ID --body "<paste the account ID>"
+   ```
+
+   Or omit `--body` to be prompted / pipe the value in:
+
+   ```bash
+   gh secret set CLOUDFLARE_API_TOKEN
+   echo -n "<account id>" | gh secret set CLOUDFLARE_ACCOUNT_ID
+   ```
+
+   If you keep these values in 1Password, pipe them straight from the `op`
+   CLI instead of copy-pasting. This assumes a `cloudflare.com` item with
+   an "Account ID" field and a per-repo "API token: `<repo>`" field:
+
+   ```bash
+   REPO="$(basename "$(git rev-parse --show-toplevel)")"
+   op item get "cloudflare.com" --fields "API token: $REPO" | gh secret set CLOUDFLARE_API_TOKEN
+   op item get "cloudflare.com" --fields "Account ID" | gh secret set CLOUDFLARE_ACCOUNT_ID
+   ```
+
+4. **Create the Cloudflare Pages project.** This must be done locally,
+   before opening a preview PR — `wrangler pages deploy` in CI does not
+   create the project on its own. Create it once with
+   [Wrangler](https://developers.cloudflare.com/workers/wrangler/)
+   (requires Node.js), run from the repo root so the project name is
+   picked up from the checkout directory rather than typed by hand, and
+   set `main` as the production branch:
+
+   ```bash
+   npx wrangler login
+   npx wrangler pages project create "$(basename "$(git rev-parse --show-toplevel)")" --production-branch main
+   ```
+
+5. **Verify the secrets are set:**
+
+   ```bash
+   gh secret list
+   ```
+
+   You should see `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` listed
+   (values are never shown, only names and update times).
+
+## After setup
+
+Once the secrets exist, every PR from a repo branch (not a fork) will get:
+
+- A live preview at a Cloudflare Pages URL specific to that PR
+  (`--branch=pr-<PR number>`), rebuilt on every push to the PR.
+- A PR comment with the preview link, edited in place on each new commit
+  rather than re-posted.
+
+## If the repository is ever renamed
+
+The Cloudflare Pages project name must be created to match the new
+repository name (Cloudflare project names can't easily be renamed once
+created). If you rename this repo, create a new Cloudflare Pages project
+matching the new name (step 4 above) — the workflow itself needs no
+changes, since it reads the project name from GitHub at deploy time.


### PR DESCRIPTION
## Summary
- Adds a `preview` job to `deploy-book` that publishes each PR's built book to Cloudflare Pages and comments the link on the PR (gated to same-repo branches, since forks can't read secrets).
- Cloudflare Pages project name is derived from the repo name (`${{ github.event.repository.name }}`), so nothing in the workflow needs updating if the repo is renamed.
- Adds `README-DEPLOYMENT.md` documenting the workflow's four jobs and the one-time Cloudflare setup (API token, account ID, project creation, optional 1Password extraction).
- Ignores the local `.wrangler/` cache directory.

Mirrors the pattern already in use in `aeadataeditor.github.io` and `stata-ssc2`.

## Test plan
- [x] `.github/workflows/main.yml` parses and runs on this PR (build job)
- [x] After the one-time Cloudflare setup (see README-DEPLOYMENT.md) is done, confirm the `preview` job deploys and comments a working preview link
- [ ] Confirm `deploy` job (push to main) still works with `book-html`/`book-pdf` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)