### PR TITLE
Add links to pipeline documentation in workflow guides

### DIFF
--- a/11-02-workflow-create-repo.md
+++ b/11-02-workflow-create-repo.md
@@ -127,7 +127,7 @@ This is where the information about the size of the deposit matters! Choose the 
 :::{admonition} If the deposit is less than 3 GB...
 :class: dropdown tip
 
-- Choose "`1-populate from ICPSR`" (might change in the future), and fill in the ID for the relevant source of the replication package (here: openICPSR ID = `123456`), and hit `Run`.
+- Choose "[`1-populate-from-icpsr`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-1-1-populate-from-icpsr)" (might change in the future), and fill in the ID for the relevant source of the replication package (here: openICPSR ID = `123456`), and hit `Run`.
 
 
 ![select pipeline](images/jira-run-pipeline-icpsr.png)
@@ -140,7 +140,7 @@ However, closely monitor the pipeline output - it might still fail because the r
 :::{admonition} If the deposit is more than 3 GB...
 :class: dropdown tip
 
-- Choose "`w-big populate from ICPSR`" (might change in the future), and fill in the ID for the relevant source of the replication package (here: openICPSR ID = `123456`), and hit `Run`.
+- Choose "[`w-big-populate-from-icpsr`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-2-w-big-populate-from-icpsr)" (might change in the future), and fill in the ID for the relevant source of the replication package (here: openICPSR ID = `123456`), and hit `Run`.
 
 
 ![select pipeline](images/jira-run-pipeline-icpsr-big.png)

--- a/11-04-workflow-parta.md
+++ b/11-04-workflow-parta.md
@@ -116,7 +116,7 @@ In this case, immediately contact the (assistant) Data Editor to obtain the corr
   git push
   ```
 
-- [ ] If the pipelines did not *split* the report, use the `3-split-report` pipeline before proceeding.
+- [ ] If the pipelines did not *split* the report, use the [`3-split-report`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-6-3-split-report) pipeline before proceeding.
   - Then `git pull` to get all the changes!
 
 ::::

--- a/11-07-workflow-writing-report.md
+++ b/11-07-workflow-writing-report.md
@@ -78,7 +78,7 @@ Be sure to have committed and pushed **all** changes to the repository before ru
 
 :::
 
-- Choose "`2-merge-report`" (might change in the future), and hit `Run`.
+- Choose "[`2-merge-report`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-5-2-merge-report)" (might change in the future), and hit `Run`.
 
 ![select pipeline](images/jira-run-pipeline-merge.png)
 
@@ -179,7 +179,7 @@ If the generated output is a PDF and you observe discrepancies, **do not take sc
 
 1. **Identify PDF output**: Locate the PDF figures produced by the replication code in the appropriate directory.
 
-2. **Run the conversion pipeline**: Use the `6-convert-eps-pdf` pipeline to convert PDFs to PNGs automatically.  
+2. **Run the conversion pipeline**: Use the [`6-convert-eps-pdf`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-9-6-convert-eps-pdf) pipeline to convert PDFs to PNGs automatically.  
    - When prompted for the path, **enter the relative path from the repo root, without quotes**.  
    - The pipeline will generate PNGs in the **same directory** as the PDFs.
 

--- a/12-jira-revision-guidance.md
+++ b/12-jira-revision-guidance.md
@@ -57,7 +57,7 @@ If you do not see pipelines run in the past, you will need to [do this manually 
 
 ![select pipeline](images/jira-select-pipeline.png)
 
-- Choose "`refresh-tools`". Hit "Run".
+- Choose "[`4-refresh-tools`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-7-4-refresh-tools)". Hit "Run".
 
 ![select pipeline](images/jira-run-pipeline-updatetools.png)
 
@@ -83,7 +83,7 @@ It will update the code in place. You don't have to do anything except wait! Onc
 :class: warning dropdown
 
 ... then you will need to rename the directory containing the author code in the repository. 
-This is conveniently done using the `5-rename-directory` pipeline:
+This is conveniently done using the [`5-rename-directory`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-8-5-rename-directory) pipeline:
 
 ![select rename pipeline](images/jira-run-pipeline-rename.png)
 

--- a/99-tricky-stuff.md
+++ b/99-tricky-stuff.md
@@ -9,7 +9,7 @@ Since October 2024, we have a pipeline script that can help you.
 
 - First, be sure to `git add` all EPS files, then `git commit` them, followed by `git push`.
 - Go to the `Pipeline` tab in Bitbucket for your repository, and 
-	- choose the `6-convert-eps-pdf` pipeline. 
+	- choose the [`6-convert-eps-pdf`](https://aeadataeditor.github.io/replication-template/automations/bitbucket-pipelines/#id-9-6-convert-eps-pdf) pipeline. 
 	- enter the `openICPSRID` that is being used (this field can also handle a deeper directory, such as `openICPSRID/replication_package`, but you will rarely need to use this).
 	- by default, the pipeline will only convert `.eps` to `.png`, but you can also select `yes` in the `ProcessPDF` field if you need PDF files.
 


### PR DESCRIPTION
## Summary
This PR adds hyperlinks to the Bitbucket Pipelines documentation for all pipeline references throughout the workflow and guidance documentation. This improves navigation and helps users quickly access detailed information about each pipeline's functionality.

## Key Changes
- Added documentation links to 6 pipeline references across 5 documentation files:
  - `1-populate-from-icpsr` pipeline in workflow creation guide
  - `w-big-populate-from-icpsr` pipeline in workflow creation guide
  - `2-merge-report` pipeline in report writing guide
  - `3-split-report` pipeline in workflow part A guide
  - `4-refresh-tools` pipeline in Jira revision guidance
  - `5-rename-directory` pipeline in Jira revision guidance
  - `6-convert-eps-pdf` pipeline in report writing guide and tricky stuff guide

## Implementation Details
- All pipeline names are now formatted as inline code with markdown links pointing to the corresponding section in the Bitbucket Pipelines automation documentation
- Link anchors follow the pattern `#id-X-pipeline-name` to direct users to specific pipeline sections
- Maintains consistency in formatting and documentation structure across all files

https://claude.ai/code/session_01JyS5kkbeLCaW4Zr7M4GoYG