### PR TITLE
Update drive letter references from L: to Z: across documentation

### DIFF
--- a/11-04-workflow-parta.md
+++ b/11-04-workflow-parta.md
@@ -218,7 +218,7 @@ When assessing the data, please take care to distinguish
 
 - data that is part of the openICPSR deposit
 - data that the README tells you to download or otherwise access
-- data that you are provided on the L-Drive, which is typically provided under an agreement with the authors, and cannot be redistributed.
+- data that you are provided on the Z-Drive, which is typically provided under an agreement with the authors, and cannot be redistributed.
 ```
 
 ## Assess the openICPSR deposit
@@ -274,7 +274,7 @@ You can now proceed to change the status to `Preliminary Report complete`. You w
     - `Redistribution not authorized`: Often, even if data are not confidential, not proprietary, etc., there may be redistribution restrictions. An example are some IPUMS data, as well as many others.
     - `Other download site provided`: When data can be downloaded elsewhere, possibly due to `licenses` or `application process`. In other cases, even if they could be provided, they may already be archived elsewhere, and are not included here. 
     - `Not found`: This should be checked when data cannot be found as per the instructions by the author. This is rarely a final finding for pre-publication verification.
-  - [ ] `NUMBEROFDATASETS` How many datasets are used in the article (whether or not they are included in the replication package you downloaded)? This is meant to include datasets that you are asked to download, or that you were given access to via the "L:" drive, or "CRADC", or some other secure mechanism.
+  - [ ] `NUMBEROFDATASETS` How many datasets are used in the article (whether or not they are included in the replication package you downloaded)? This is meant to include datasets that you are asked to download, or that you were given access to via the "Z:" drive, or "CRADC", or some other secure mechanism.
 
 
 ## Next steps

--- a/11-05-preparing-to-run-code.md
+++ b/11-05-preparing-to-run-code.md
@@ -214,7 +214,7 @@ When getting the data, please take care to distinguish
 
 - data that is part of the openICPSR deposit
 - data that the README tells you to download or otherwise access
-- data that you are provided on the L-Drive, which is typically provided under an agreement with the authors, and cannot be redistributed.
+- data that you are provided on the Z-Drive, which is typically provided under an agreement with the authors, and cannot be redistributed.
 
 
 Here, we will describe the most likely first step: getting the data from openICPSR. Any data you download should also be stored on this computer. We do not explicitly describe this here. **CCSS** is the most likely place where you do this, but double-check with your supervisor.
@@ -243,7 +243,7 @@ In all cases, you should obtain the data from the deposit, and otherwise follow 
 :::{tab-item} CCSS
 
 - [ ] Access the CCSS environment: [shortcut to Cloud](https://client.wvd.microsoft.com/arm/webclient/v2/index.html), for other access, see [Appendix](windows-remote).
-- [ ] In some cases, you may be asked to use (restricted) data on the S: drive or L: drive. Follow instructions as you receive them.
+- [ ] In some cases, you may be asked to use (restricted) data on the S: drive or Z: drive. Follow instructions as you receive them.
 - [ ] Download the openICPSR data (if available). 
   - Try to do this first using scripts. See [the details in the appendix](using-pre-pub-openicpsr). 
     ```bash

--- a/20-checking-unassigned-tickets.md
+++ b/20-checking-unassigned-tickets.md
@@ -111,7 +111,7 @@ Check if the case is a Revision by going to the Other Links tab and clicking the
 - Update the bitbucket short name with the repository name of the previous cases.
 - Check if the older Jira ticket had restricted access data (i.e. Working location of restricted data was filled out). If yes:
     - Link Issue, select type "relates to" and add the aearep-xxx for the subtask "Request Restricted Access Data for AEAREP-nnn"
-    - Fill out Working location of restricted data with the same L drive path
+    - Fill out Working location of restricted data with the same Z drive path
     - Fill out Agreement Signed to match the older Jira ticket
 
 ## Non-standard unassigned cases

--- a/33-jira-delete-nda-data.md
+++ b/33-jira-delete-nda-data.md
@@ -35,7 +35,7 @@ You should move the Jira issue to the `Delete NDA Data` status by choosing `Dele
 
 ## Delete the data
 
-- [ ] CCSS-Cloud: Delete the data from the L-Drive.
+- [ ] CCSS-Cloud: Delete the data from the Z-Drive.
 - [ ] If some processing occurred on BioHPC: Confirm deletion with the RA, or delete the entire `aearep-xxxx` folder.
 - [ ] Box: Follow instructions at [LDI Research Aide guide](https://aeadataeditor.github.io/LDI-Research-Aide/procedures/Requesting_Restricted_Access_Data/#once-case-is-done)
 

--- a/94-03-private-data.md
+++ b/94-03-private-data.md
@@ -24,8 +24,8 @@ You should then look into the "`Data`" tab for the field `Working location of re
 :::{tab-item} CCSS Cloud
 
 - Log into remote desktop as usual.
-- The restricted access data will be stored in the L drive. If you haven't mapped the L drive, do that first ([instructions here](https://labordynamicsinstitute.github.io/ldilab-manual/95-10-windows-remote.html)).
-- Navigate to the folder `Restricted-Access-Data` and find the corresponding folder that is in the Jira field, e.g., `L:\Restricted-Access-Data\aearep-4400`.
+- The restricted access data will be stored in the Z drive. If you haven't mapped the Z drive, do that first ([instructions here](https://labordynamicsinstitute.github.io/ldilab-manual/95-10-windows-remote.html)).
+- Navigate to the folder `Restricted-Access-Data` and find the corresponding folder that is in the Jira field, e.g., `Z:\Restricted-Access-Data\aearep-4400`.
 - If there is a ZIP file (looks like a folder, but is not), right-click and choose `Extract All` before working in the folder
 
 :::
@@ -64,9 +64,9 @@ There are two ways to run code using the data in this folder:
 
 More robust, but maybe a bit more work, is to modify the code to reference the confidential data every time it is called.
 
-- In the `config.do`, is a line `global sdrive ""`. Modify that line to read `global sdrive "L:\Restricted-Access-Data\aearep-3756"`
+- In the `config.do`, is a line `global sdrive ""`. Modify that line to read `global sdrive "Z:\Restricted-Access-Data\aearep-3756"`
 - Run the code in its usual location. When the code encounters (absent) confidential data in the usual location, it will break/stop.
-- Everywhere you encounter references to confidential data in the code, e.g., `use "${datadir}/mysuper.dta"`, modify the code to reference the L-drive: `use "${sdrive}/mysuper.dta`. 
+- Everywhere you encounter references to confidential data in the code, e.g., `use "${datadir}/mysuper.dta"`, modify the code to reference the Z-drive: `use "${sdrive}/mysuper.dta`. 
 - commit all code modifications, output, and log files as you normally would.
 
 ## Examples
@@ -104,7 +104,7 @@ global results "$path/output"
 #### Adjusting for LDI specific situation
 
 1. Include the `config.do` in the master file as usual.
-2. In the `config.do`, adjust the (existing) global for the L: drive: `global sdrive "L:\Restricted-Access-Data\aearep-4991-nda_Implicit"`. The global is defined at the very end of the `config.do`.
+2. In the `config.do`, adjust the (existing) global for the Z: drive: `global sdrive "Z:\Restricted-Access-Data\aearep-4991-nda_Implicit"`. The global is defined at the very end of the `config.do`.
 3. In the master file, incorporate the `rootdir` from the `config.do` as the main global `path`. This should reflect your workspace on the U: drive.
 4. Incorporate the new global `sdrive` to set the authors' global `confidential`. 
 

--- a/94-05-globus-transfers.md
+++ b/94-05-globus-transfers.md
@@ -24,7 +24,7 @@ Look for the Globus icon on the desktop:
 - Ensure that it contains at least the following entry:
 
 ```
-L:\
+Z:\
 ```
 
 ## Transferring files

--- a/95-10-windows-remote.md
+++ b/95-10-windows-remote.md
@@ -30,7 +30,7 @@ Pay attention to the precise access instructions, as they may be substantially d
 
 :::{admonition} Please be sure to do this:
 
-- use the L drive for all "Workspace" folders (i.e., the clone of the Bitbucket repository)
+- use the Z drive for all "Workspace" folders (i.e., the clone of the Bitbucket repository)
 - use the D drive for those that are large and need fast storage (but be aware that D drive is also wiped)
 -  **ALWAYS**  `git commit` and `git push`  all changes before you logout, every time you log out.
 
@@ -67,8 +67,8 @@ use the [https://client.wvd.microsoft.com/arm/webclient/](https://client.wvd.mic
 
 **Mapping Network Drives**
 
-- You should map the following network drive, following the CCSS storage/network-drive instructions linked above. However, use `L:`, not `Z:`. `L:` is the LDI-specific drive letter for this setup. 
-  - `\\ccssilr.file.core.windows.net\lv39` to drive letter `L:` (you can call it "LDILab Drive")
+- You should map the following network drive, following the CCSS storage/network-drive instructions linked above, using drive letter `Z:`. `Z:` is the LDI-specific drive letter for this setup. 
+  - `\\ccssilr.file.core.windows.net\lv39` to drive letter `Z:` (you can call it "LDILab Drive")
   - We will be using that drive letter often. 
 
 
@@ -102,7 +102,7 @@ CCSS has removed their login instructions at this time!
 
 :::{admonition} Please be sure to do this:
 
-- use the L drive for all "Workspace" folders (i.e., the clone of the Bitbucket repository)
+- use the Z drive for all "Workspace" folders (i.e., the clone of the Bitbucket repository)
 
 :::
 
@@ -157,11 +157,11 @@ Continue log in using the password you created in step 3.
 
 **Mapping Network Drives**
 
-Network drives are already mapped in RedCloud. To access the shared "L-Drive", follow these steps:
+Network drives are already mapped in RedCloud. To access the shared "Z-Drive", follow these steps:
 
 1. Open File Explorer
 2. Click ‘This PC’
-3.	Underneath ‘Devices and Drives’ you will see the L: drive titled ‘lv39’
+3.	Underneath ‘Devices and Drives’ you will see the Z: drive titled ‘lv39’
 
 ![RedCloudL](images/RedCloudLdrive.png)
 

--- a/95-10-windows-remote.md
+++ b/95-10-windows-remote.md
@@ -67,7 +67,7 @@ use the [https://client.wvd.microsoft.com/arm/webclient/](https://client.wvd.mic
 
 **Mapping Network Drives**
 
-- You should map the following network drive, following the CCSS storage/network-drive instructions linked above, using drive letter `Z:`. `Z:` is the LDI-specific drive letter for this setup. 
+- You should map the following network drive, following the CCSS storage/network-drive instructions linked above, using drive letter `Z:`.
   - `\\ccssilr.file.core.windows.net\lv39` to drive letter `Z:` (you can call it "LDILab Drive")
   - We will be using that drive letter often. 
 

--- a/96-01-using-config-stata.md
+++ b/96-01-using-config-stata.md
@@ -151,7 +151,7 @@ Z:/Workspace/aearep-9999/111111
 ```
 
 
-- line 97, `global logdir "${rootdir}/logs"` sets the following directory as a directory for log files: `U:/Workspace/aearep-9999/111111/logs`. Note that it will automatically use the `$rootdir` created earlier based on your choice of scenario.
+- line 97, `global logdir "${rootdir}/logs"` sets the following directory as a directory for log files: `Z:/Workspace/aearep-9999/111111/logs`. Note that it will automatically use the `$rootdir` created earlier based on your choice of scenario.
 
 ```
 global logdir "${rootdir}/logs"

--- a/96-01-using-config-stata.md
+++ b/96-01-using-config-stata.md
@@ -147,7 +147,7 @@ local ssc_packages "estout ivreg2"
 `config.do` creates a subdirectory and saves log files in the subdirectory. Let's say the current working directory path is the following, since Jira issue number is `AEAREP-9999` and openICPSR case number is `111111`
 
 ```
-L:/Workspace/aearep-9999/111111
+Z:/Workspace/aearep-9999/111111
 ```
 
 

--- a/96-11-using-config-r.md
+++ b/96-11-using-config-r.md
@@ -40,10 +40,10 @@ These packages will be installed into the project's `renv` library, so they are 
 
 ### Confidential data location
 
-In some cases, authors provide us privately with data that is not part of the public replication package (the part on openICPSR is generally public). We put this on the L-drive, or what used to be called the S-drive. Put the location of that here, if any:
+In some cases, authors provide us privately with data that is not part of the public replication package (the part on openICPSR is generally public). We put this on the Z-drive, or what used to be called the S-drive. Put the location of that here, if any:
 
 ```
-sdrive <- "L:/Workspace/aearep-9999-implicit-nda"
+sdrive <- "Z:/Workspace/aearep-9999-implicit-nda"
 ```
 
 :::{note}
@@ -51,7 +51,7 @@ sdrive <- "L:/Workspace/aearep-9999-implicit-nda"
 If you are working on Windows (e.g. CCSS-Cloud) then you would need to use `/` or `\\` to write filepaths or use the file.path() function. So, for example, the above would become:
 
 ```
-sdrive <- "L:\\Workspace\\aearep-9999-implicit-nda"
+sdrive <- "Z:\\Workspace\\aearep-9999-implicit-nda"
 ```
 
 :::

--- a/96-16-debugging-r.md
+++ b/96-16-debugging-r.md
@@ -205,7 +205,7 @@ ERROR*> JavaSoft\{JRE|JDK} can't open registry keys.
 ERROR: cannot find Java Development Kit.
   Please set JAVA_HOME to specify its location manually
 ERROR: configuration failed for package 'rJava'
-* removing 'L:/Workspace/aearep-XXXX/123456/renv/library/windows/R-4.4/x86_64-w64-mingw32/.renv/1/rJava'
+* removing 'Z:/Workspace/aearep-XXXX/123456/renv/library/windows/R-4.4/x86_64-w64-mingw32/.renv/1/rJava'
 install of package 'rJava' failed [error code 1]
 ```
 
@@ -216,7 +216,7 @@ The resolutions specified here are only suitable for Windows systems like CCSS-C
 First, confirm whether azulJava files are present in the locations specified in the examples below. They won't be on all systems. If you find the files then, at the beginning of the R script, place the following:
 
 ```
-Sys.setenv(JAVA_HOME='L:\\common\\azulJava\\jdk\\jre')
+Sys.setenv(JAVA_HOME='Z:\\common\\azulJava\\jdk\\jre')
 install.packages("rJava")
 library(rJava)
 ```
@@ -224,7 +224,7 @@ library(rJava)
 If that doesn't work, try:
 
 ```
-Sys.setenv(JAVA_HOME = "L:/common/azulJava/jdk")
+Sys.setenv(JAVA_HOME = "Z:/common/azulJava/jdk")
 install.packages("rJava")
 library(rJava)
 ```

--- a/96-23-dynare-matlab.md
+++ b/96-23-dynare-matlab.md
@@ -5,7 +5,7 @@ Dynare is often used as an extension from within MATLAB. Files are usually ident
 
 :::{warning} 
 
-Use the precise version of Dynare specified by the authors. If that version is not located on `L:\common` (CCSS Cloud) or `/home2/ecco_lv39/software` or as a Docker file, then talk to your supervisor.
+Use the precise version of Dynare specified by the authors. If that version is not located on `Z:\common` (CCSS Cloud) or `/home2/ecco_lv39/software` or as a Docker file, then talk to your supervisor.
 
 :::
 
@@ -25,7 +25,7 @@ However, it is not necessary to *install* Dynare, it is sufficient to unpack the
 :::
 
 
-If a specific version is mentioned and is not there, download it from the [Dynare website](https://www.dynare.org/download/) - choose the **ZIP** version. Then unzip it to the `L: drive` (move it around if necessary so you get the same structure as in the example above, i.e. `L:\common\dynare\(SOME VERSION)\matlab`). Then include the `addpath` command as before.
+If a specific version is mentioned and is not there, download it from the [Dynare website](https://www.dynare.org/download/) - choose the **ZIP** version. Then unzip it to the `Z: drive` (move it around if necessary so you get the same structure as in the example above, i.e. `Z:\common\dynare\(SOME VERSION)\matlab`). Then include the `addpath` command as before.
 
 ::::
 
@@ -85,8 +85,8 @@ $dockerbin run --rm -it \
 % The following are possible Dynare settings. Uncomment the one you need.
 
 % dynarepath = "/Applications/Dynare/4.6.1/matlab"
-% dynarepath = "L:\LDILab\dynare\dynare-4.5.7\matlab"
-%dynarepath = "L:\common\dynare-4.5.7\matlab"
+% dynarepath = "Z:\LDILab\dynare\dynare-4.5.7\matlab"
+%dynarepath = "Z:\common\dynare-4.5.7\matlab"
 
 % 
 % Then uncomment the following line:
@@ -94,7 +94,7 @@ $dockerbin run --rm -it \
 %addpath(genpath(dynarepath))
 ```
 
-- You will want the path for the system you are working on. If CCSS Cloud, use the `L:` path. If on BioHPC, you will need to add a path like `/home2/ecco_lv39/software/dynare-x.y.z`.
+- You will want the path for the system you are working on. If CCSS Cloud, use the `Z:` path. If on BioHPC, you will need to add a path like `/home2/ecco_lv39/software/dynare-x.y.z`.
 - Then uncomment the `addpath()` statement at the end.
 
 Your modified `config.m` should look somewhat like this:
@@ -105,9 +105,9 @@ Your modified `config.m` should look somewhat like this:
 % The following are possible Dynare settings. Uncomment the one you need.
 
 % dynarepath = "/Applications/Dynare/4.6.1/matlab"
-% dynarepath = "L:\LDILab\dynare\dynare-4.5.7\matlab"
+% dynarepath = "Z:\LDILab\dynare\dynare-4.5.7\matlab"
 
-dynarepath = "L:\common\dynare-4.5.7\matlab"
+dynarepath = "Z:\common\dynare-4.5.7\matlab"
 
 % 
 % Then uncomment the following line:

--- a/96-30-running-python-jupyter.md
+++ b/96-30-running-python-jupyter.md
@@ -176,35 +176,6 @@ If the authors provide a list of packages, the easiest way is to create a simple
 ::::
 
 
-### Using Anaconda Package manager
-
-This is known to work on  CISER (CCSS-Classic).
-
-:::{admonition}  This may not be the way it works on CCSS-Cloud. 
-:class: dropdown
-Needs an update
-:::
-
-If using the default "Jupyter" link in the Start Menu, the working directory won't be right. Assuming that you have set your Workspace to `Z:\Documents\Workspace`, the following will create a Jupyter Notebook in the right location (thanks to Louis Liu for creating this Howto)
-
-#### Search "anaconda prompt" from the start menu. right click on the app when it appears and pin it to the taskbar.
-
-![Step 1](images/Jupyter_howto_step1.png)
-
-#### Right click on anaconda prompt in the taskbar (looks like a black window, similar to command line or terminal). Right click on "anaconda powershell prompt" in the tasks menu that pops up, and then properties.
-
-![Step 2](images/Jupyter_howto_step2.png)
-
-#### In the properties window, go to the shortcut tab and change the "Start in:" field to U:\Documents\Workspace or whichever directory you keep your bitbucket repos in. Click apply.
-
-![Step 3](images/Jupyter_howto_step3.png)
-
-#### Next, click on the anaconda prompt shortcut in the taskbar. When anaconda prompt opens, enter the command "`Jupyter notebook`"
-
-![Step 4](images/Jupyter_howto_step4.png)
-
-
-
 ## Running Jupyter Notebooks
 
 ### Interactively

--- a/96-30-running-python-jupyter.md
+++ b/96-30-running-python-jupyter.md
@@ -185,7 +185,7 @@ This is known to work on  CISER (CCSS-Classic).
 Needs an update
 :::
 
-If using the default "Jupyter" link in the Start Menu, the working directory won't be right. Assuming that you have set your Workspace to `L:\Documents\Workspace`, the following will create a Jupyter Notebook in the right location (thanks to Louis Liu for creating this Howto)
+If using the default "Jupyter" link in the Start Menu, the working directory won't be right. Assuming that you have set your Workspace to `Z:\Documents\Workspace`, the following will create a Jupyter Notebook in the right location (thanks to Louis Liu for creating this Howto)
 
 #### Search "anaconda prompt" from the start menu. right click on the app when it appears and pin it to the taskbar.
 


### PR DESCRIPTION
## Summary
This PR updates all references to the network drive letter from `L:` to `Z:` across the documentation. This reflects a change in the LDI Lab's CCSS Cloud infrastructure configuration where the shared network drive is now mapped to the `Z:` drive instead of the `L:` drive.

## Key Changes
- Updated all CCSS Cloud network drive path references from `L:\` to `Z:\` in configuration and workflow documentation
- Updated Dynare configuration examples and instructions to use `Z:` drive paths
- Updated Windows remote access documentation to reflect `Z:` drive mapping for `\\ccssilr.file.core.windows.net\lv39`
- Updated restricted access data location references from L-Drive to Z-Drive across multiple guides
- Updated R configuration examples (`config.R`) to use `Z:` drive paths
- Updated Stata configuration examples (`config.do`) to use `Z:` drive paths
- Updated workflow and procedure documentation to reference Z-Drive instead of L-Drive
- Removed outdated Anaconda Package Manager section from Jupyter documentation (no longer applicable to current CCSS setup)

## Notable Details
- All file path examples have been systematically updated to maintain consistency across the documentation
- Both forward slash (`/`) and backslash (`\`) path formats have been updated where applicable
- References in code comments, configuration examples, and procedural instructions have all been updated
- The change applies to CCSS Cloud environment specifically; BioHPC and other systems remain unchanged

https://claude.ai/code/session_01VZAju9uui8ftzUfwFiL8tb